### PR TITLE
Add a secondary needs-review PHPCS.

### DIFF
--- a/checks/phpcs.php
+++ b/checks/phpcs.php
@@ -26,6 +26,19 @@ class PHPCS_Checks extends Check_Base {
 		);
 	}
 
+	function check_against_phpcs_review() {
+		if ( ! HAS_VENDOR ) {
+			return new Notice(
+				'phpcs_not_tested',
+				'PHP CS rulesets have not been tested, as the vendor directory is missing. Perhaps you need to run <code>`composer install`</code>.'
+			);
+		}
+
+		return $this->run_phpcs_standard(
+			__DIR__ . '/phpcs/plugin-check-needs-review.xml'
+		);
+	}
+
 	protected function run_phpcs_standard( string $standard, array $args = [] ) {
 		$phpcs = new PHPCS();
 		$phpcs->set_standard( $standard );

--- a/checks/phpcs/plugin-check-needs-review.xml
+++ b/checks/phpcs/plugin-check-needs-review.xml
@@ -44,6 +44,8 @@
 				<element key="hex2bin" value="null"/>
 				<element key="base64_decode" value="null"/>
 				<element key="base64_encode" value="null"/>
+				<element key="shell_exec" value="null"/>
+				<element key="exec" value="null"/>
 			</property>
 		</properties>
 	</rule>

--- a/checks/phpcs/plugin-check-needs-review.xml
+++ b/checks/phpcs/plugin-check-needs-review.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0"?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="WPPluginCheck" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/squizlabs/PHP_CodeSniffer/master/phpcs.xsd">
+	<!--
+		This file should have any rules that are not appropriate for the main plugin-check.xml file.
+		These should be items that are strictly needs to be manually reviewed.
+	-->
+
+	<!-- For more information: https://make.wordpress.org/plugins/handbook/review/ -->
+	<description>Standards any plugin to be published on wordpress.org should comply with.</description>
+
+	<!--
+	Prevent errors caused by WordPress Coding Standards not supporting PHP 8.0+.
+	See https://github.com/WordPress/WordPress-Coding-Standards/issues/2035
+	-->
+	<ini name="error_reporting" value="E_ALL &#38; ~E_DEPRECATED" />
+
+	<arg name="report" value="code"/>
+	<arg value="s"/>
+
+	<!-- Plugins should be compatible with PHP 5.2 and higher. -->
+	<config name="testVersion" value="5.2-"/>
+
+	<exclude-pattern>*/tgm-plugin-activation/*</exclude-pattern>
+	<exclude-pattern>*/freemius/*</exclude-pattern>
+	<exclude-pattern>*/dompdf/*</exclude-pattern>
+	<exclude-pattern>*/cmb2/*</exclude-pattern>
+	<exclude-pattern>*/redux-framework/*</exclude-pattern>
+	<exclude-pattern>*/cherry-framework/*</exclude-pattern>
+	<exclude-pattern>*/titan-framework/*</exclude-pattern>
+	<exclude-pattern>*/vendor/*</exclude-pattern>
+	<exclude-pattern>*/guzzlehttp/*</exclude-pattern>
+	<exclude-pattern>*/vendors/*</exclude-pattern>
+	<exclude-pattern>*/plugin-update-checker/*</exclude-pattern>
+	<exclude-pattern>*/composer_directory/*</exclude-pattern>
+	<exclude-pattern>*/node_modules/*</exclude-pattern>
+
+	<rule ref="Generic.PHP.ForbiddenFunctions">
+		<type>warning</type>
+		<properties>
+			<property name="forbiddenFunctions" type="array">
+				<element key="error_reporting" value="null"/>
+				<element key="move_uploaded_file" value="null"/>
+				<element key="wp_create_user" value="null"/>
+				<element key="hex2bin" value="null"/>
+			</property>
+		</properties>
+	</rule>
+
+</ruleset>

--- a/checks/phpcs/plugin-check-needs-review.xml
+++ b/checks/phpcs/plugin-check-needs-review.xml
@@ -42,6 +42,8 @@
 				<element key="move_uploaded_file" value="null"/>
 				<element key="wp_create_user" value="null"/>
 				<element key="hex2bin" value="null"/>
+				<element key="base64_decode" value="null"/>
+				<element key="base64_encode" value="null"/>
 			</property>
 		</properties>
 	</rule>

--- a/checks/phpcs/plugin-check.xml
+++ b/checks/phpcs/plugin-check.xml
@@ -83,19 +83,6 @@
 			</property>
 		</properties>
 	</rule>
-	<!-- Hmm.. Can't have a second instance of this.. bad error message anyway
-	<rule ref="Generic.PHP.ForbiddenFunctions">
-		<type>warning</type>
-		<properties>
-			<property name="forbiddenFunctions" type="array">
-				<element key="error_reporting" value="null"/>
-				<element key="move_uploaded_file" value="null"/>
-				<element key="wp_create_user" value="null"/>
-				<element key="hex2bin" value="null"/>
-			</property>
-		</properties>
-	</rule>
-	-->
 
 	<!-- Check for use of deprecated WordPress classes, functions and function parameters. -->
 	<rule ref="WordPress.WP.DeprecatedClasses"/>


### PR DESCRIPTION
PHPCS can only run rules with one set of arguments it appears, causing some issues where we want to use one rule and have multiple error levels come out of it.

This works around that by running a duplicate PHPCS check. This is not the most optimal, and there may be an option to simply have a primary ruleset that loads the others? This however works-for-now.

This should cover #21, #24, #25, #26, #15