### PR TITLE
Add application files check

### DIFF
--- a/checks/check-base.php
+++ b/checks/check-base.php
@@ -158,4 +158,18 @@ abstract class Check_Base {
 
 		return $cache[ $file ] ?? $cache[ $file ] = file_get_contents( $file );
 	}
+
+	/**
+	 * Throw an error or a warning, based on the environment.
+	 *
+	 * @param string $file The filename.
+	 * @return string
+	 */
+	function throw_notice( $code, $message ) {
+
+		$notice_or_error = ( ( defined( 'WP_DEBUG' ) && WP_DEBUG ) || 'production' !== wp_get_environment_type() ) ? Notice::class : Error::class;
+
+		return new $notice_or_error( $code, $message );
+
+	}
 }

--- a/checks/file-checks.php
+++ b/checks/file-checks.php
@@ -36,7 +36,7 @@ class File_Checks extends Check_Base {
 	}
 
 	function check_application() {
-		$application_files = [ '.sh', '.exe', '.a', '.bin', '.bpk', '.deploy', '.dist', '.distz', '.dmg', '.dms', '.dump', '.elc', '.iso', '.lha', '.lrf', '.lzh', '.o', '.obj', '.pkg', '.so' ];
+		$application_files = [ '.a', '.bin', '.bpk', '.deploy', '.dist', '.distz', '.dmg', '.dms', '.dump', '.elc', '.exe', '.iso', '.lha', '.lrf', '.lzh', '.o', '.obj', '.phar', '.pkg', '.sh', '.so' ];
 
 		$files = array_filter( $this->files, function( $file ) use ( $application_files ) {
 			$extension = sprintf( '.%s', pathinfo( $file, PATHINFO_EXTENSION ) );

--- a/checks/file-checks.php
+++ b/checks/file-checks.php
@@ -36,7 +36,7 @@ class File_Checks extends Check_Base {
 	}
 
 	function check_application() {
-		$application_files = [ '.a', '.bin', '.bpk', '.deploy', '.dist', '.distz', '.dmg', '.dms', '.dump', '.elc', '.exe', '.iso', '.lha', '.lrf', '.lzh', '.o', '.obj', '.phar', '.pkg', '.sh', '.so' ];
+		$application_files = [ '.a', '.bin', '.bpk', '.deploy', '.dist', '.distz', '.dmg', '.dms', '.DS_Store', '.dump', '.elc', '.exe', '.iso', '.lha', '.lrf', '.lzh', '.o', '.obj', '.phar', '.pkg', '.sh', '.so' ];
 
 		$files = array_filter( $this->files, function( $file ) use ( $application_files ) {
 			$extension = sprintf( '.%s', pathinfo( $file, PATHINFO_EXTENSION ) );

--- a/checks/file-checks.php
+++ b/checks/file-checks.php
@@ -36,7 +36,30 @@ class File_Checks extends Check_Base {
 	}
 
 	function check_application() {
-		$application_files = [ '.a', '.bin', '.bpk', '.deploy', '.dist', '.distz', '.dmg', '.dms', '.DS_Store', '.dump', '.elc', '.exe', '.iso', '.lha', '.lrf', '.lzh', '.o', '.obj', '.phar', '.pkg', '.sh', '.so' ];
+		$application_files = [
+			'.a',
+			'.bin',
+			'.bpk',
+			'.deploy',
+			'.dist',
+			'.distz',
+			'.dmg',
+			'.dms',
+			'.DS_Store',
+			'.dump',
+			'.elc',
+			'.exe',
+			'.iso',
+			'.lha',
+			'.lrf',
+			'.lzh',
+			'.o',
+			'.obj',
+			'.phar',
+			'.pkg',
+			'.sh',
+			'.so'
+		];
 
 		$files = array_filter( $this->files, function( $file ) use ( $application_files ) {
 			$extension = sprintf( '.%s', pathinfo( $file, PATHINFO_EXTENSION ) );
@@ -49,7 +72,7 @@ class File_Checks extends Check_Base {
 			return new $notice_or_error(
 				'application_detected',
 				sprintf(
-					'Application files are not permitted. Found: %s',
+					__( 'Application files are not permitted. Found: %s', 'wporg-plugins' ),
 					implode( ', ', array_unique( array_map( function( $file ) {
 						return '<code>' . esc_html( $file ) . '</code>';
 					}, $files ) ) )

--- a/checks/file-checks.php
+++ b/checks/file-checks.php
@@ -35,6 +35,29 @@ class File_Checks extends Check_Base {
 		}
 	}
 
+	function check_application() {
+		$application_files = [ '.sh', '.exe', '.a', '.bin', '.bpk', '.deploy', '.dist', '.distz', '.dmg', '.dms', '.dump', '.elc', '.iso', '.lha', '.lrf', '.lzh', '.o', '.obj', '.pkg', '.so' ];
+
+		$files = array_filter( $this->files, function( $file ) use ( $application_files ) {
+			$extension = sprintf( '.%s', pathinfo( $file, PATHINFO_EXTENSION ) );
+			return in_array( $extension, $application_files, true );
+		} );
+
+		if ( $files ) {
+			$notice_or_error = ( ( defined( 'WP_DEBUG' ) && WP_DEBUG ) || 'production' !== wp_get_environment_type() ) ? Notice::class : Error::class;
+
+			return new $notice_or_error(
+				'application_detected',
+				sprintf(
+					'Application files are not permitted. Found: %s',
+					implode( ', ', array_unique( array_map( function( $file ) {
+						return '<code>' . esc_html( $file ) . '</code>';
+					}, $files ) ) )
+				)
+			);
+		}
+	}
+
 	function check_vcs() {
 		$directories = [ '.git', '.svn', '.hg', '.bzr' ];
 

--- a/checks/file-checks.php
+++ b/checks/file-checks.php
@@ -67,9 +67,8 @@ class File_Checks extends Check_Base {
 		} );
 
 		if ( $files ) {
-			$notice_or_error = ( ( defined( 'WP_DEBUG' ) && WP_DEBUG ) || 'production' !== wp_get_environment_type() ) ? Notice::class : Error::class;
 
-			return new $notice_or_error(
+			return $this->throw_notice(
 				'application_detected',
 				sprintf(
 					__( 'Application files are not permitted. Found: %s', 'wporg-plugins' ),
@@ -78,6 +77,7 @@ class File_Checks extends Check_Base {
 					}, $files ) ) )
 				)
 			);
+
 		}
 	}
 
@@ -89,17 +89,17 @@ class File_Checks extends Check_Base {
 		} );
 
 		if ( $files ) {
-			$notice_or_error = ( ( defined( 'WP_DEBUG' ) && WP_DEBUG ) || 'production' !== wp_get_environment_type() ) ? Notice::class : Error::class;
-
-			return new $notice_or_error(
+			
+			return $this->throw_notice(
 				'vcs_present',
 				sprintf(
-					'Version control checkouts should not be present. Found: %s',
+					__( 'Version control checkouts should not be present. Found: %s', 'wporg-plugins' ),
 					implode( ', ', array_unique( array_map( function( $file ) {
 						return '<code>' . esc_html( basename( dirname( $file ) ) ) . '</code>';
 					}, $files ) ) )
 				)
 			);
+
 		}
 	}
 


### PR DESCRIPTION
Resolves https://github.com/WordPress/plugin-check/issues/1

Check for any application files present in the plugin.

Checks for:
.sh, .exe, .a, .bin, .bpk, .deploy, .dist, .distz, .dmg, .dms, .dump, .elc, .iso, .lha, .lrf, .lzh, .o, .obj, .pkg, .so