### PR TITLE
Add push-to-WordPress.org for releasing the plugin

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,10 +44,3 @@ jobs:
                   branch: build
                   force: true
                   message: 'Build: ${{ github.sha }}'
-
-            - name: WordPress Plugin Deploy
-              uses: 10up/action-wordpress-plugin-deploy@stable
-              env:
-                SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
-                SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
-

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,3 +44,10 @@ jobs:
                   branch: build
                   force: true
                   message: 'Build: ${{ github.sha }}'
+
+            - name: WordPress Plugin Deploy
+              uses: 10up/action-wordpress-plugin-deploy@stable
+              env:
+                SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+                SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,34 @@
+name: Deploy
+
+# Run deploy only on published releases.
+on:
+  release:
+    types: [published]
+
+jobs:
+
+  deploy:
+    name: Deploy to WordPress.org
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: WordPress Plugin Deploy
+        id: deploy
+        uses: 10up/action-wordpress-plugin-deploy@stable
+        with:
+          generate-zip: true
+        env:
+          SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+          SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+
+      - name: Upload release asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ${{ steps.deploy.outputs.zip-path }}
+          asset_name: ${{ github.event.repository.name }}.zip
+          asset_content_type: application/zip

--- a/readme.txt
+++ b/readme.txt
@@ -1,0 +1,16 @@
+Plugin Check
+===============
+* Contributors: dd32, davidperezgar
+* Requires at least: 6.2
+* Tested up to: 6.3
+* License: GPLv2 or later
+* License URI: http://www.gnu.org/licenses/gpl-2.0.html
+
+Plugin Check is a tool from the WordPress.org plugin review team, it provides an initial check of whether your plugin meets our requirements for hosting.
+
+## Description #
+
+Plugin Check is a tool from the WordPress.org plugin review team.
+It provides an initial check of whether your plugin meets our requirements for hosting.
+
+Development occurs within https://github.com/WordPress/plugin-check/, please submit PRs and Bug Reports there.


### PR DESCRIPTION
This uses the 10up plugin deployer, and creates a dedicated readme.txt for WordPress.org usage (Which allows the Readme.MD to be used for Github-specific content).

The plugin is currently disabled on WordPress.org, but can be re-enabled once this is intended on being released.

~NOTE: This build push occurs on every commit, rather than upon a release being made on Github, I'm not sure if this is a problem, but I don't think is how the 10up plugin deployer is intended on being used.~

Perhaps it should be:
 - This build step pushes to `trunk` on plugins.svn (This would then be used by WordPress.org production for checking plugins, but not for those who install the plugin for testing locally). ❌  _Probably best not to do this, for w.org stability._
 - A new deploy action is added that deploys releases made (A release would then just be tagged from the `build` branch). ✅  _this has been done below_

Probably needs some more thought put into it..