### PR TITLE
Disallow functions: move_uploaded_file, passthru, proc_open

### DIFF
--- a/checks/phpcs/plugin-check-needs-review.xml
+++ b/checks/phpcs/plugin-check-needs-review.xml
@@ -39,7 +39,6 @@
 		<properties>
 			<property name="forbiddenFunctions" type="array">
 				<element key="error_reporting" value="null"/>
-				<element key="move_uploaded_file" value="null"/>
 				<element key="wp_create_user" value="null"/>
 				<element key="hex2bin" value="null"/>
 				<element key="base64_decode" value="null"/>

--- a/checks/phpcs/plugin-check.xml
+++ b/checks/phpcs/plugin-check.xml
@@ -77,6 +77,9 @@
 	<rule ref="Generic.PHP.ForbiddenFunctions">
 		<properties>
 			<property name="forbiddenFunctions" type="array">
+				<element key="move_uploaded_file" value="null"/>
+				<element key="passthru" value="null"/>
+				<element key="proc_open" value="null"/>
 				<element key="create_function" value="null"/>
 				<element key="eval" value="null"/>
 				<element key="str_rot13" value="null"/>

--- a/tests/checks/test-phpcs-review.php
+++ b/tests/checks/test-phpcs-review.php
@@ -25,7 +25,6 @@ class Test_PHPCS_Review extends PluginCheck_TestCase {
 	public function data_forbidden_function_warnings() {
 		return [
 			[ 'error_reporting()',    'error_reporting( E_ALL );' ],
-			[ 'move_uploaded_file()', 'move_uploaded_file( $a, $b );' ],
 			[ 'wp_create_user()',     'wp_create_user( "admin", "admin" );' ],
 			[ 'hex2bin()',            'echo hex2bin( "313031" );' ],
 			[ 'base64_encode()',      'echo base64_encode( "WordPress" );' ],

--- a/tests/checks/test-phpcs.php
+++ b/tests/checks/test-phpcs.php
@@ -42,9 +42,12 @@ class Test_PHPCS extends PluginCheck_TestCase {
 
 	public function data_forbidden_function_warnings() {
 		return [
-			[ 'create_function()', 'create_function( "example", "return 123;" );' ],
-			[ 'eval()',            'eval( $_POST["cmd"] );' ],
-			[ 'str_rot13()',       'echo str_rot13( "JbeqCerff" );' ],
+			[ 'create_function()',    'create_function( "example", "return 123;" );' ],
+			[ 'eval()',               'eval( $_POST["cmd"] );' ],
+			[ 'str_rot13()',          'echo str_rot13( "JbeqCerff" );' ],
+			[ 'move_uploaded_file()', 'move_uploaded_file( $a, $b );' ],
+			[ 'passthru()',           'passthru( $cmd );' ],
+			[ 'proc_open()',          'proc_open( $cmd, $descriptors, $pipes );' ],
 		];
 	}
 


### PR DESCRIPTION
Fixes #21 
Fixes #34 

Moves the `move_uploaded_file` disallowed function to `plugin-check.xml` to make it an Error rather than a Warning (#21).

Adds Errors for `passthru` and `proc_open` (#34)