### PR TITLE
Include a way to modify the PHP Binary Path

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,4 +26,5 @@ Commands:
 
 = [1.0.0] TBD =
 
+* Feature - Enable modification of the PHP Binary path used by the plugin with `PLUGIN_CHECK_PHP_BIN` constant.
 * Tweak - Disallow functions `move_uploaded_file`, `passthru`, `proc_open` - Props alexsanford at [#50](https://github.com/WordPress/plugin-check/pull/50)

--- a/checks/phpcs.php
+++ b/checks/phpcs.php
@@ -4,6 +4,7 @@ use const WordPressdotorg\Plugin_Check\{ PLUGIN_DIR, HAS_VENDOR };
 use WordPressdotorg\Plugin_Check\{Error, Guideline_Violation, Message, Notice, Warning};
 use WordPressdotorg\Plugin_Check\PHPCS;
 
+include PLUGIN_DIR . '/inc/class-php-cli.php';
 include PLUGIN_DIR . '/inc/class-phpcs.php';
 
 class PHPCS_Checks extends Check_Base {
@@ -57,6 +58,13 @@ class PHPCS_Checks extends Check_Base {
 			$args,
 			'array'
 		);
+
+		if ( is_wp_error( $report ) ) {
+			return new Error(
+				$report->get_error_code(),
+				$report->get_error_message()
+			);
+		}
 
 		// If no response, either malformed output or PHP encountered an error.
 		if ( ! $report || empty( $report['files'] ) ) {

--- a/inc/class-php-cli.php
+++ b/inc/class-php-cli.php
@@ -1,0 +1,71 @@
+<?php
+namespace WordPressdotorg\Plugin_Check;
+
+/**
+ * Class Class_PHP_CLI
+ *
+ * @since   TBD
+ *
+ * @package WordPressdotorg\Plugin_Check
+ */
+class PHP_CLI {
+	/**
+	 * Gets the path to the PHP cli.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return string
+	 */
+	protected function get_php_binary(): string {
+		if ( defined( 'PLUGIN_CHECK_PHP_BIN' ) && ! empty( PLUGIN_CHECK_PHP_BIN ) ) {
+			$php_binary = PLUGIN_CHECK_PHP_BIN;
+		} else {
+			$php_binary = 'php';
+		}
+
+		/**
+		 * Allows overriding the PHP binary used to run phpcs and other php commands.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param string $php_binary The path to the PHP binary.
+		 */
+		return (string) apply_filters( 'plugin_check_get_php_binary', $php_binary );
+	}
+
+	/**
+	 * Gets the PHP base command to run scripts.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return string
+	 */
+	protected function get_php_cmd(): string {
+		$php_cmd_parts[] = '/usr/bin/env';
+
+		$php_cmd_parts[] = $this->get_php_binary();
+
+		$php_cmd_parts[] = '-dmemory_limit=1G';
+
+		// Give the CLI process the same max_execution_time as the calling script.
+		if ( ini_get( 'max_execution_time' ) ) {
+			$php_cmd_parts[] = '-dmax_execution_time=' . ini_get( 'max_execution_time' );
+		}
+
+		return implode( ' ', $php_cmd_parts );
+	}
+
+	/**
+	 * Gets the full command to run.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $append
+	 *
+	 * @return string
+	 */
+	public function get_cmd( string $append = '' ): string {
+		return $this->get_php_cmd() . ' ' . $append;
+	}
+
+}

--- a/inc/class-php-cli.php
+++ b/inc/class-php-cli.php
@@ -2,9 +2,9 @@
 namespace WordPressdotorg\Plugin_Check;
 
 /**
- * Class Class_PHP_CLI
+ * Class PHP_CLI
  *
- * @since   TBD
+ * @since   1.0.0
  *
  * @package WordPressdotorg\Plugin_Check
  */


### PR DESCRIPTION
When I installed this plugin locally I encountered a problem, my correct PHP version is not the one I have as the "default" for the system, so this PR addresses this problem, by allowing someone to include a constant on their `wp-config.php` to point to the correct path.

I also moved the PHP CLI path building to it's own class, enabling the PHPCS class to have proper separation of concerns.

One last thing done here was an improvement to the error when the PHP binary is not found, instead of message that is unclear what to do next.

---
| ![screenshot-2023-08-31-00-35-54](https://github.com/WordPress/plugin-check/assets/236579/81e0a242-21a0-4b88-a07f-770019061b57) | ![screenshot-2023-08-31-00-37-08](https://github.com/WordPress/plugin-check/assets/236579/76abca37-6ce9-43fb-b460-9cb6df68716b) |
|:-:|:-:|
| Previous Error | New Error |

