### PR TITLE
Include the Readme Parser 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
 		"phpcompatibility/phpcompatibility-wp": "^2",
 		"sirbrillig/phpcs-variable-analysis": "^2",
 		"wp-coding-standards/wpcs": "^2",
-		"phpcsstandards/phpcsutils": "^1.x-dev"
+		"phpcsstandards/phpcsutils": "^1.x-dev",
+		"afragen/wordpress-plugin-readme-parser": "dev-master"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "^7",

--- a/plugin.php
+++ b/plugin.php
@@ -83,10 +83,7 @@ function run_all_checks( $args ) {
 
 	if ( ! $args['readme'] ) {
 		$readme_files = preg_grep( '!(^|/)readme.(txt|md)$!i', $top_level_files );
-		if ( ! class_exists( '\WordPressdotorg\Plugin_Directory\Readme\Parser' ) && file_exists( __DIR__ . '/readme-parser.php' ) ) {
-			require_once __DIR__ . '/readme-parser.php';
-		}
-		if ( $readme_files && class_exists( '\WordPressdotorg\Plugin_Directory\Readme\Parser' ) ) {
+		if ( $readme_files ) {
 			$args['readme'] = new Readme_Parser( array_shift( $readme_files ) );
 		}
 	}

--- a/readme.txt
+++ b/readme.txt
@@ -24,4 +24,5 @@ Development occurs within https://github.com/WordPress/plugin-check/, please sub
 * Feature - Include a check for the usage of `ALLOW_UNFILTERED_UPLOADS` on any PHP files - Props EvanHerman at [#45](https://github.com/WordPress/plugin-check/pull/45)
 * Feature - Include a check for the presence of the application files (`.a`, `.bin`, `.bpk`, `.deploy`, `.dist`, `.distz`, `.dmg`, `.dms`, `.DS_Store`, `.dump`, `.elc`, `.exe`, `.iso`, `.lha`, `.lrf`, `.lzh`, `.o`, `.obj`, `.phar`, `.pkg`, `.sh`, '.so`) - Props EvanHerman at [#43](https://github.com/WordPress/plugin-check/pull/43)
 * Feature - Include a check for the presence of the readme.txt or readme.md file - Props EvanHerman at [#42](https://github.com/WordPress/plugin-check/pull/42)
+* Fix - Ensure that Readme parsing is included properly when a readme.md or readme.txt file is present. Props Bordoni [#52](https://github.com/WordPress/plugin-check/pull/52)
 * Tweak - Disallow functions `move_uploaded_file`, `passthru`, `proc_open` - Props alexsanford at [#50](https://github.com/WordPress/plugin-check/pull/50)


### PR DESCRIPTION
As I was testing the code further I realized that the Readme Parser was not being included properly, or at least the file didn't exist locally for me. So I modified how the code handles the inclusion to ensure we have the file via the composer autoloading.